### PR TITLE
Autosuggest fix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,9 @@ export default class App extends Component {
 
   getTripsByUserId = async () => {
     const response = await axios.get('/trips', {withCredentials: true})
+    console.log(" ");
+    console.log("Here's what App knows about:");
+    console.log(response);
     this.setState({
       trips: response.data
     })

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -117,7 +117,7 @@ export default class Dashboard extends Component {
                 lat={clickedTrip.lat} 
                 lon={clickedTrip.lon} 
                 photos={photos} 
-                updateApp={this.props.updateAppDashboard} 
+                updateAppDashboard={this.props.updateApp} 
             /> 
             : 
             null;        

--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -13,6 +13,7 @@ export default class TripDetails extends React.Component{
         super(props);
         this.state = {
             name : this.props.name,
+            value : this.props.name,
             date : this.props.date,
             details : this.props.details,
             editPhotos : false, // changing the photos?
@@ -42,7 +43,7 @@ export default class TripDetails extends React.Component{
         const { value, suggestions, files, photos,  } = this.state; // a little destructuring for conveinence 
         const inputProps = {
             placeholder: 'Choose a destination',
-            value, // this.state.value aka what's in the input box right now
+            value: this.state.value, // this.state.value aka what's in the input box right now
             onChange: this.updateAutosuggestField
         };
         const renderSuggestion = (suggestion, { query, isHighlighted }) => {
@@ -83,7 +84,7 @@ export default class TripDetails extends React.Component{
                 </div>
                     <span className='card-title'>
                         <h2 className='trip-title' onBlur={(e)=>{this._updateName(e.target.textContent);}} contentEditable={true} suppressContentEditableWarning={true} >{name}</h2>
-                    {/* <Autosuggest 
+                    <Autosuggest 
                             suggestions={suggestions} // this.state.suggestions to select from
                             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested} // where Axios and the filtering happens
                             onSuggestionsClearRequested={this.onSuggestionsClearRequested} // onBlur(-ish), clears the rendered suggestions
@@ -93,9 +94,10 @@ export default class TripDetails extends React.Component{
                             highlightFirstSuggestion={true} // cues the user that they need to select one of these options
                             focusInputOnSuggestionClick={false} // when you take a suggestion, the input blurs
                             className='trip-title' 
-                            onBlur={()=>{this._updateName();}} contentEditable={true} 
-                            suppressContentEditableWarning={true}
-                        /> */}
+                            // onBlur={()=>{this._updateName();}} 
+                            // contentEditable={true} 
+                            // suppressContentEditableWarning={true}
+                        />
                     </span>
                     <div className='card-action grey-text'>
                         {/* <div onBlur={(e)=>{this._updateDate(e.target.textContent);}} contentEditable={true} suppressContentEditableWarning={true} >{date}</div> */}
@@ -161,7 +163,7 @@ export default class TripDetails extends React.Component{
             // we need to POST to db as well as alert the Dashboard 
             // component that it's time to freshly render with the latest from DB
 
-            const {name, location, details, lat, lon} = this.state
+            const {value, location, details, lat, lon} = this.state
             let date1 = document.getElementById(`editTripDate${this.props.id}`).value.toString() 
             const date = moment(date1, 'MMM Do YYYY').format("YYYY-MM-DD")
             const propsDate = moment(this.props.date).format("YYYY-MM-DD")
@@ -177,7 +179,7 @@ export default class TripDetails extends React.Component{
                 axios.delete(`trips/delete/${this.props.id}`)
                 .then(this.props.updateApp)
             }
-            if((name!==this.props.name)||(date!==propsDate)||(details!==this.props.details)){
+            if((value!==this.props.name)||(date!==propsDate)||(details!==this.props.details)){
                 console.log("prop id: ", this.props.id);
                 axios.post(`/trips/edit/${this.props.id}`, body)
                 .then(this.props.updateApp)

--- a/src/components/trips/TripDetails.js
+++ b/src/components/trips/TripDetails.js
@@ -169,7 +169,7 @@ export default class TripDetails extends React.Component{
             const propsDate = moment(this.props.date).format("YYYY-MM-DD")
 
             const body = {
-                trip_location : location,
+                trip_location : value,
                 trip_date : date,
                 lat,
                 lon,
@@ -177,12 +177,12 @@ export default class TripDetails extends React.Component{
             }
             if(this.state.deleteThisTrip){
                 axios.delete(`trips/delete/${this.props.id}`)
-                .then(this.props.updateApp)
+                .then(() => {console.log("firing updateAppDashboard!!");this.props.updateAppDashboard()})
             }
             if((value!==this.props.name)||(date!==propsDate)||(details!==this.props.details)){
                 console.log("prop id: ", this.props.id);
                 axios.post(`/trips/edit/${this.props.id}`, body)
-                .then(this.props.updateApp)
+                .then(() => {console.log("firing updateAppDashboard!!");this.props.updateAppDashboard()})
             }
 
             this.props.shutTheDoorBehindYou();


### PR DESCRIPTION
**Bug**
Site would crash when trying to open a TripDetails modal after it had been previously edited.

**Fix**
- The `inputProps` for the `AutoSuggest` component had an initial value prop that it should get from state. Adding it to state (and giving it the value of the trip location name) solved the problem.
- The TripList not refreshing with the edit to the location (nor the pin in Mapbox) was due to not firing the function passed into props meant to trigger a refresh request for tripsByUser from the backend. (mea culpa)